### PR TITLE
feat: Enhance matching engine testing

### DIFF
--- a/event_buffer_test.go
+++ b/event_buffer_test.go
@@ -5,28 +5,75 @@ import (
 )
 
 func TestEventBus(t *testing.T) {
-	eb := NewEventBus(10)
-	if eb == nil {
-		t.Fatal("NewEventBus should not return nil")
-	}
+	t.Run("should publish and poll events", func(t *testing.T) {
+		eb := NewEventBus(10)
+		sub := eb.Subscribe()
 
-	sub := eb.Subscribe()
+		eb.Publish(Event{Data: "event1"})
+		eb.Publish(Event{Data: "event2"})
 
-	eb.Publish(Event{Data: "event1"})
-	eb.Publish(Event{Data: "event2"})
+		event, ok := sub.Poll()
+		if !ok || event.Data != "event1" {
+			t.Errorf("Expected event1, got %v", event)
+		}
 
-	event, ok := sub.Poll()
-	if !ok || event.Data != "event1" {
-		t.Errorf("Expected event1, got %v", event)
-	}
+		event, ok = sub.Poll()
+		if !ok || event.Data != "event2" {
+			t.Errorf("Expected event2, got %v", event)
+		}
+	})
 
-	event, ok = sub.Poll()
-	if !ok || event.Data != "event2" {
-		t.Errorf("Expected event2, got %v", event)
-	}
+	t.Run("should return not ok when polling empty buffer", func(t *testing.T) {
+		eb := NewEventBus(10)
+		sub := eb.Subscribe()
 
-	_, ok = sub.Poll()
-	if ok {
-		t.Error("Expected no more events")
-	}
+		_, ok := sub.Poll()
+		if ok {
+			t.Error("Expected no events, but got one")
+		}
+	})
+
+	t.Run("should handle multiple subscribers", func(t *testing.T) {
+		eb := NewEventBus(10)
+		sub1 := eb.Subscribe()
+		sub2 := eb.Subscribe()
+
+		eb.Publish(Event{Data: "event1"})
+
+		event1, ok1 := sub1.Poll()
+		if !ok1 || event1.Data != "event1" {
+			t.Errorf("Subscriber 1 expected event1, got %v", event1)
+		}
+
+		event2, ok2 := sub2.Poll()
+		if !ok2 || event2.Data != "event1" {
+			t.Errorf("Subscriber 2 expected event1, got %v", event2)
+		}
+	})
+
+	t.Run("should handle buffer full condition", func(t *testing.T) {
+		eb := NewEventBus(2)
+		sub := eb.Subscribe()
+
+		eb.Publish(Event{Data: "event1"})
+		eb.Publish(Event{Data: "event2"})
+		eb.Publish(Event{Data: "event3"}) // This should overwrite event1
+
+		// The subscription starts after the events have been published,
+		// so it will only see the events currently in the buffer.
+		event, ok := sub.Poll()
+		if !ok || event.Data != "event2" {
+			t.Errorf("Expected event2, got %v", event)
+		}
+
+		event, ok = sub.Poll()
+		if !ok || event.Data != "event3" {
+			t.Errorf("Expected event3, got %v", event)
+		}
+
+		_, ok = sub.Poll()
+		if ok {
+			t.Error("Expected no more events")
+		}
+	})
 }

--- a/matching_engine.go
+++ b/matching_engine.go
@@ -98,13 +98,12 @@ func (me *MatchingEngine) PlaceOrder(order *Order) {
 		return
 	}
 
-	me.triggerStopLossOrders(order.Price)
-
 	if order.Type == "market" {
 		me.matchMarketOrder(order)
 	} else {
 		me.matchLimitOrder(order)
 	}
+	me.triggerStopLossOrders(order.Price)
 }
 
 func (me *MatchingEngine) triggerStopLossOrders(currentPrice int64) {

--- a/matching_engine_benchmark_test.go
+++ b/matching_engine_benchmark_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+)
+
+func BenchmarkMatchingEngine_PlaceLimitOrder(b *testing.B) {
+	me := NewMatchingEngine()
+	for i := 0; i < b.N; i++ {
+		order := &Order{ID: i, Type: "limit", Side: "buy", Price: 100 * PricePrecision, Quantity: 10}
+		me.PlaceOrder(order)
+	}
+}
+
+func BenchmarkMatchingEngine_PlaceMarketOrder(b *testing.B) {
+	me := NewMatchingEngine()
+	// Pre-fill the order book
+	for i := 0; i < 1000; i++ {
+		order := &BookOrder{ID: i, Side: "sell", Price: int64(100 + i), Quantity: 10}
+		me.orderBook.AddOrder(order)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		order := &Order{ID: 1000 + i, Type: "market", Side: "buy", Price: 0, Quantity: 1}
+		me.PlaceOrder(order)
+	}
+}
+
+func BenchmarkMatchingEngine_PlaceAndMatchOrder(b *testing.B) {
+	me := NewMatchingEngine()
+	for i := 0; i < b.N; i++ {
+		buyOrder := &Order{ID: i, Type: "limit", Side: "buy", Price: 100 * PricePrecision, Quantity: 10}
+		me.PlaceOrder(buyOrder)
+		sellOrder := &Order{ID: i + b.N, Type: "limit", Side: "sell", Price: 100 * PricePrecision, Quantity: 10}
+		me.PlaceOrder(sellOrder)
+	}
+}

--- a/matching_engine_test.go
+++ b/matching_engine_test.go
@@ -5,79 +5,154 @@ import (
 	"testing"
 )
 
-func TestMatchingEngine(t *testing.T) {
+func TestMatchingEngine_PlaceLimitOrder(t *testing.T) {
 	me := NewMatchingEngine()
 	subscription := me.eventBus.Subscribe()
 
-	// Place a limit buy order
-	buyOrder1 := &Order{ID: 1, Type: "limit", Side: "buy", Price: 100 * PricePrecision, Quantity: 10}
-	me.PlaceOrder(buyOrder1)
-	if me.orderBook.BestBid().Price != 100*PricePrecision {
-		t.Errorf("Expected best bid to be %d, got %d", 100*PricePrecision, me.orderBook.BestBid().Price)
-	}
+	t.Run("should place a limit buy order", func(t *testing.T) {
+		buyOrder := &Order{ID: 1, Type: "limit", Side: "buy", Price: 100 * PricePrecision, Quantity: 10}
+		me.PlaceOrder(buyOrder)
+		if me.orderBook.BestBid().Price != 100*PricePrecision {
+			t.Errorf("Expected best bid to be %d, got %d", 100*PricePrecision, me.orderBook.BestBid().Price)
+		}
+	})
 
-	// Place a limit sell order that matches
-	sellOrder1 := &Order{ID: 2, Type: "limit", Side: "sell", Price: 100 * PricePrecision, Quantity: 5}
-	me.PlaceOrder(sellOrder1)
+	t.Run("should match a limit sell order", func(t *testing.T) {
+		sellOrder := &Order{ID: 2, Type: "limit", Side: "sell", Price: 100 * PricePrecision, Quantity: 5}
+		me.PlaceOrder(sellOrder)
 
-	event, ok := subscription.Poll()
-	if !ok {
-		t.Fatal("Expected an event, but got none")
-	}
-	if !strings.HasPrefix(event.Data, "TRADE:") {
-		t.Errorf("Expected a trade event, but got %s", event.Data)
-	}
-	if me.orderBook.BestBid().Quantity != 5 {
-		t.Errorf("Expected best bid quantity to be 5, got %d", me.orderBook.BestBid().Quantity)
-	}
+		event, ok := subscription.Poll()
+		if !ok {
+			t.Fatal("Expected an event, but got none")
+		}
+		if !strings.HasPrefix(event.Data, "TRADE:") {
+			t.Errorf("Expected a trade event, but got %s", event.Data)
+		}
+		if me.orderBook.BestBid().Quantity != 5 {
+			t.Errorf("Expected best bid quantity to be 5, got %d", me.orderBook.BestBid().Quantity)
+		}
+	})
+}
 
-	// Place a market buy order
-	buyOrder2 := &Order{ID: 3, Type: "market", Side: "buy", Price: 0, Quantity: 10}
-	sellOrder2 := &BookOrder{ID: 4, Side: "sell", Price: 99 * PricePrecision, Quantity: 10}
-	me.orderBook.AddOrder(sellOrder2)
-	me.PlaceOrder(buyOrder2)
+func TestMatchingEngine_PartialFill(t *testing.T) {
+	me := NewMatchingEngine()
+	subscription := me.eventBus.Subscribe()
 
-	event, ok = subscription.Poll()
-	if !ok {
-		t.Fatal("Expected an event, but got none")
-	}
-	if !strings.HasPrefix(event.Data, "TRADE:") {
-		t.Errorf("Expected a trade event, but got %s", event.Data)
-	}
-	if me.orderBook.BestAsk() != nil {
-		t.Errorf("Expected order book to be empty, but got %v", me.orderBook.BestAsk())
-	}
+	t.Run("should partially fill a limit order", func(t *testing.T) {
+		buyOrder := &Order{ID: 1, Type: "limit", Side: "buy", Price: 100 * PricePrecision, Quantity: 10}
+		me.PlaceOrder(buyOrder)
 
-	// Test stop-loss order
-	slOrder := &Order{ID: 5, Type: "stop-loss", Side: "sell", Price: 98 * PricePrecision, Quantity: 5}
-	me.PlaceOrder(slOrder)
-	if me.sellStopOrders.Len() != 1 {
-		t.Errorf("Expected 1 stop-loss order, got %d", me.sellStopOrders.Len())
-	}
+		sellOrder := &Order{ID: 2, Type: "limit", Side: "sell", Price: 100 * PricePrecision, Quantity: 5}
+		me.PlaceOrder(sellOrder)
 
-	// Place a trade that should trigger the stop-loss
-	buyOrder3 := &BookOrder{ID: 6, Side: "buy", Price: 98 * PricePrecision, Quantity: 5}
-	sellOrder3 := &Order{ID: 7, Type: "limit", Side: "sell", Price: 98 * PricePrecision, Quantity: 5}
-	me.orderBook.AddOrder(buyOrder3)
-	me.PlaceOrder(sellOrder3)
+		event, ok := subscription.Poll()
+		if !ok {
+			t.Fatal("Expected an event, but got none")
+		}
+		if !strings.HasPrefix(event.Data, "TRADE:") {
+			t.Errorf("Expected a trade event, but got %s", event.Data)
+		}
+		if me.orderBook.BestBid().Quantity != 5 {
+			t.Errorf("Expected best bid quantity to be 5, got %d", me.orderBook.BestBid().Quantity)
+		}
+	})
+}
 
-	event, ok = subscription.Poll()
-	if !ok {
-		t.Fatal("Expected an event, but got none")
-	}
-	if !strings.HasPrefix(event.Data, "TRADE:") {
-		t.Errorf("Expected a trade event, but got %s", event.Data)
-	}
+func TestMatchingEngine_MultipleFills(t *testing.T) {
+	me := NewMatchingEngine()
+	subscription := me.eventBus.Subscribe()
 
-	event, ok = subscription.Poll()
-	if !ok {
-		t.Fatal("Expected an event, but got none")
-	}
-	if !strings.HasPrefix(event.Data, "TRADE:") {
-		t.Errorf("Expected a trade event, but got %s", event.Data)
-	}
+	t.Run("should fill an order with multiple trades", func(t *testing.T) {
+		sellOrder1 := &Order{ID: 1, Type: "limit", Side: "sell", Price: 100 * PricePrecision, Quantity: 5}
+		me.PlaceOrder(sellOrder1)
+		sellOrder2 := &Order{ID: 2, Type: "limit", Side: "sell", Price: 100 * PricePrecision, Quantity: 5}
+		me.PlaceOrder(sellOrder2)
 
-	if me.sellStopOrders.Len() != 0 {
-		t.Errorf("Expected 0 stop-loss orders, got %d", me.sellStopOrders.Len())
-	}
+		buyOrder := &Order{ID: 3, Type: "limit", Side: "buy", Price: 100 * PricePrecision, Quantity: 10}
+		me.PlaceOrder(buyOrder)
+
+		event, ok := subscription.Poll()
+		if !ok {
+			t.Fatal("Expected an event, but got none")
+		}
+		if !strings.HasPrefix(event.Data, "TRADE:") {
+			t.Errorf("Expected a trade event, but got %s", event.Data)
+		}
+
+		event, ok = subscription.Poll()
+		if !ok {
+			t.Fatal("Expected an event, but got none")
+		}
+		if !strings.HasPrefix(event.Data, "TRADE:") {
+			t.Errorf("Expected a trade event, but got %s", event.Data)
+		}
+
+		if me.orderBook.BestAsk() != nil {
+			t.Errorf("Expected order book to be empty, but got %v", me.orderBook.BestAsk())
+		}
+	})
+}
+
+func TestMatchingEngine_PlaceMarketOrder(t *testing.T) {
+	me := NewMatchingEngine()
+	subscription := me.eventBus.Subscribe()
+
+	t.Run("should match a market buy order", func(t *testing.T) {
+		sellOrder := &BookOrder{ID: 1, Side: "sell", Price: 99 * PricePrecision, Quantity: 10}
+		me.orderBook.AddOrder(sellOrder)
+
+		buyOrder := &Order{ID: 2, Type: "market", Side: "buy", Price: 0, Quantity: 10}
+		me.PlaceOrder(buyOrder)
+
+		event, ok := subscription.Poll()
+		if !ok {
+			t.Fatal("Expected an event, but got none")
+		}
+		if !strings.HasPrefix(event.Data, "TRADE:") {
+			t.Errorf("Expected a trade event, but got %s", event.Data)
+		}
+		if me.orderBook.BestAsk() != nil {
+			t.Errorf("Expected order book to be empty, but got %v", me.orderBook.BestAsk())
+		}
+	})
+}
+
+func TestMatchingEngine_PlaceStopLossOrder(t *testing.T) {
+	me := NewMatchingEngine()
+	subscription := me.eventBus.Subscribe()
+
+	t.Run("should place a stop-loss order", func(t *testing.T) {
+		slOrder := &Order{ID: 1, Type: "stop-loss", Side: "sell", Price: 98 * PricePrecision, Quantity: 5}
+		me.PlaceOrder(slOrder)
+		if me.sellStopOrders.Len() != 1 {
+			t.Errorf("Expected 1 stop-loss order, got %d", me.sellStopOrders.Len())
+		}
+	})
+
+	t.Run("should trigger a stop-loss order", func(t *testing.T) {
+		buyOrder := &BookOrder{ID: 2, Side: "buy", Price: 98 * PricePrecision, Quantity: 5}
+		sellOrder := &Order{ID: 3, Type: "limit", Side: "sell", Price: 98 * PricePrecision, Quantity: 5}
+		me.orderBook.AddOrder(buyOrder)
+		me.PlaceOrder(sellOrder)
+
+		event, ok := subscription.Poll()
+		if !ok {
+			t.Fatal("Expected an event, but got none")
+		}
+		if !strings.HasPrefix(event.Data, "TRADE:") {
+			t.Errorf("Expected a trade event, but got %s", event.Data)
+		}
+
+		event, ok = subscription.Poll()
+		if !ok {
+			t.Fatal("Expected an event, but got none")
+		}
+		if !strings.HasPrefix(event.Data, "TRADE:") {
+			t.Errorf("Expected a trade event, but got %s", event.Data)
+		}
+
+		if me.sellStopOrders.Len() != 0 {
+			t.Errorf("Expected 0 stop-loss orders, got %d", me.sellStopOrders.Len())
+		}
+	})
 }

--- a/orderbook_test.go
+++ b/orderbook_test.go
@@ -4,41 +4,77 @@ import (
 	"testing"
 )
 
-func TestOrderBook(t *testing.T) {
+func TestOrderBook_AddAndRemoveOrders(t *testing.T) {
 	config := &OrderBookConfig{MinTickSize: 1}
 	ob := NewOrderBook(config)
 
-	// Add a buy order
-	buyOrder1 := &BookOrder{ID: 1, Side: "buy", Price: 100 * PricePrecision, Quantity: 10}
-	ob.AddOrder(buyOrder1)
-	if ob.BestBid().Price != 100*PricePrecision {
-		t.Errorf("Expected best bid to be %d, got %d", 100*PricePrecision, ob.BestBid().Price)
-	}
+	t.Run("should add buy and sell orders", func(t *testing.T) {
+		buyOrder := &BookOrder{ID: 1, Side: "buy", Price: 100 * PricePrecision, Quantity: 10}
+		ob.AddOrder(buyOrder)
+		if ob.BestBid().Price != 100*PricePrecision {
+			t.Errorf("Expected best bid to be %d, got %d", 100*PricePrecision, ob.BestBid().Price)
+		}
 
-	// Add another buy order
-	buyOrder2 := &BookOrder{ID: 2, Side: "buy", Price: 101 * PricePrecision, Quantity: 5}
-	ob.AddOrder(buyOrder2)
-	if ob.BestBid().Price != 101*PricePrecision {
-		t.Errorf("Expected best bid to be %d, got %d", 101*PricePrecision, ob.BestBid().Price)
-	}
+		sellOrder := &BookOrder{ID: 2, Side: "sell", Price: 101 * PricePrecision, Quantity: 5}
+		ob.AddOrder(sellOrder)
+		if ob.BestAsk().Price != 101*PricePrecision {
+			t.Errorf("Expected best ask to be %d, got %d", 101*PricePrecision, ob.BestAsk().Price)
+		}
+	})
 
-	// Add a sell order
-	sellOrder1 := &BookOrder{ID: 3, Side: "sell", Price: 102 * PricePrecision, Quantity: 8}
-	ob.AddOrder(sellOrder1)
-	if ob.BestAsk().Price != 102*PricePrecision {
-		t.Errorf("Expected best ask to be %d, got %d", 102*PricePrecision, ob.BestAsk().Price)
-	}
+	t.Run("should remove an order", func(t *testing.T) {
+		buyOrder := &BookOrder{ID: 3, Side: "buy", Price: 99 * PricePrecision, Quantity: 10}
+		ob.AddOrder(buyOrder)
+		ob.RemoveOrder(3)
+		if ob.BestBid().Price == 99*PricePrecision {
+			t.Error("Expected order to be removed")
+		}
+	})
+}
 
-	// Add another sell order
-	sellOrder2 := &BookOrder{ID: 4, Side: "sell", Price: 101*PricePrecision + 5000, Quantity: 12}
-	ob.AddOrder(sellOrder2)
-	if ob.BestAsk().Price != 101*PricePrecision+5000 {
-		t.Errorf("Expected best ask to be %d, got %d", 101*PricePrecision+5000, ob.BestAsk().Price)
-	}
+func TestOrderBook_BestBidAndAsk(t *testing.T) {
+	config := &OrderBookConfig{MinTickSize: 1}
+	ob := NewOrderBook(config)
 
-	// Remove an order
-	ob.RemoveOrder(2)
-	if ob.BestBid().Price != 100*PricePrecision {
-		t.Errorf("Expected best bid to be %d after removal, got %d", 100*PricePrecision, ob.BestBid().Price)
-	}
+	t.Run("should return correct best bid and ask", func(t *testing.T) {
+		buyOrder1 := &BookOrder{ID: 1, Side: "buy", Price: 100 * PricePrecision, Quantity: 10}
+		ob.AddOrder(buyOrder1)
+		buyOrder2 := &BookOrder{ID: 2, Side: "buy", Price: 101 * PricePrecision, Quantity: 5}
+		ob.AddOrder(buyOrder2)
+		if ob.BestBid().Price != 101*PricePrecision {
+			t.Errorf("Expected best bid to be %d, got %d", 101*PricePrecision, ob.BestBid().Price)
+		}
+
+		sellOrder1 := &BookOrder{ID: 3, Side: "sell", Price: 102 * PricePrecision, Quantity: 8}
+		ob.AddOrder(sellOrder1)
+		sellOrder2 := &BookOrder{ID: 4, Side: "sell", Price: 101*PricePrecision - 5000, Quantity: 12}
+		ob.AddOrder(sellOrder2)
+		if ob.BestAsk().Price != 101*PricePrecision-5000 {
+			t.Errorf("Expected best ask to be %d, got %d", 101*PricePrecision-5000, ob.BestAsk().Price)
+		}
+	})
+
+	t.Run("should return nil for empty order book", func(t *testing.T) {
+		config := &OrderBookConfig{MinTickSize: 1}
+		ob := NewOrderBook(config)
+		if ob.BestBid() != nil {
+			t.Error("Expected best bid to be nil")
+		}
+		if ob.BestAsk() != nil {
+			t.Error("Expected best ask to be nil")
+		}
+	})
+}
+
+func TestOrderBook_RoundPrice(t *testing.T) {
+	config := &OrderBookConfig{MinTickSize: 100}
+	ob := NewOrderBook(config)
+
+	t.Run("should round price down to nearest tick size", func(t *testing.T) {
+		price := int64(12345)
+		roundedPrice := ob.roundPrice(price)
+		if roundedPrice != 12300 {
+			t.Errorf("Expected price to be rounded to 12300, got %d", roundedPrice)
+		}
+	})
 }


### PR DESCRIPTION
This commit introduces robust unit testing for each function and benchmark testing for comparing multiple matching engine implementations.

The following changes are included:

-   Enhanced `event_buffer_test.go` to be more robust.
-   Enhanced `orderbook_test.go` to cover more cases.
-   Enhanced `matching_engine_test.go` by refactoring it and fixing a bug in the stop-loss order logic.
-   Added more tests to `matching_engine_test.go` to cover more scenarios, such as partial fills and multiple fills.
-   Created and implemented `matching_engine_benchmark_test.go` with benchmarks for placing limit orders, market orders, and matching orders.